### PR TITLE
[FEATURE] 에디터 수정 (폰트 크기, 코드블록)

### DIFF
--- a/src/APP/admin-pages/MakingCurriculum/Styled/MakingCurriculum.makingcurriculum.quilleditor.styles.js
+++ b/src/APP/admin-pages/MakingCurriculum/Styled/MakingCurriculum.makingcurriculum.quilleditor.styles.js
@@ -47,5 +47,11 @@ export const EditorWrapper = styled.div`
   .ql-toolbar .ql-formats {
     margin-right: 0;
   }
-    
+    .ql-syntax {
+  background-color: #ffffff;  /* 검정색 배경 */
+  color: #abb2bf;  /* 밝은 텍스트 색 */
+  padding: 10px;
+  border-radius: 4px;
+  font-family: 'Courier New', Courier, monospace;
+}
 `;

--- a/src/APP/admin-pages/MakingRegularStudy/MakingRegularStudy.makingregularstudy.editstudyinfo.jsx
+++ b/src/APP/admin-pages/MakingRegularStudy/MakingRegularStudy.makingregularstudy.editstudyinfo.jsx
@@ -6,6 +6,7 @@ import { useDropzone } from 'react-dropzone';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AlertContext } from '../../Common/Alert/AlertContext';
 import { useContext } from 'react';
+import { hardCodedContent } from './tmpContentData';
 
 export default function MakingRegularStudyEditStudyInfo() {
     const { id } = useParams();  //해당 스터디의 id를 파라미터로 가져온다
@@ -31,6 +32,7 @@ export default function MakingRegularStudyEditStudyInfo() {
             setName(infoResponse.result.studyName);
             setImageUrl(infoResponse.result.profileUrl);
             setContent(homeResponse.result);
+            // setContent(hardCodedContent);
             setLoading(false);
         } catch (error) {
             console.error('데이터 불러오기 오류:', error);
@@ -111,7 +113,7 @@ export default function MakingRegularStudyEditStudyInfo() {
         }
         
         // 에디터 수정을 위한 출력
-        console.log("########################## 에디터에서 보낸 데이터: ", requestData);
+        // console.log("########################## 에디터에서 보낸 데이터: ", requestData);
     };
 
     if (loading) return <div>Loading...</div>;

--- a/src/APP/admin-pages/MakingRegularStudy/tmpContentData.js
+++ b/src/APP/admin-pages/MakingRegularStudy/tmpContentData.js
@@ -1,0 +1,14 @@
+export const hardCodedContent = `
+ "<p><strong>이 문장은 Arial 폰트로, <em>18px</em> 크기에 <u>굵고</u> <s>취소선</s>이 있습니다.</strong></p><p>이 문장은 Arial 폰트로, <strong><em>18px</em> 크기에 <u>굵고</u> <s>취소선</s>이 있습니다.</strong></p><ol><li>첫 번째 항목 (Verdana)</li><li>두 번째 항목 (Tahoma)</li><li>세 번째 항목 (Comic Sans MS)</li></ol><ul><li>첫 번째 점 항목 (Helvetica, 20px)</li><li>두 번째 점 항목 (Trebuchet MS, 22px)</li><li>세 번째 점 항목 (Impact, 24px)</li></ul><p>왼쪽 정렬된 문장 (Garamond)</p><p class="ql-align-right">오른쪽 정렬된 문장 (Palatino Linotype)</p><p><a href="https://www.example.com" rel="noopener noreferrer" target="_blank">이곳을 클릭하면 Example 웹사이트로 이동합니다. (Lucida Sans)</a></p><p>사진 예시:</p><p><img src="https://via.placeholder.com/150"></p><p><br></p><p><br></p><pre class="ql-syntax" spellcheck="false">#include &lt;iostream&gt;
+using namesapce std;
+
+
+string s;
+
+
+int main(){
+	cin &gt;&gt; s;
+	cout &lt;&lt; "asdfasdfasdfasdfasdfasdfasdfaaaaaaaaaaaaaaa";
+}
+</pre>"
+`;

--- a/src/APP/admin-pages/RegularStudy/RegularStudy.regularstudy.home.jsx
+++ b/src/APP/admin-pages/RegularStudy/RegularStudy.regularstudy.home.jsx
@@ -2,6 +2,9 @@ import React, { useEffect, useState } from 'react'
 import * as itemS from "../RegularStudy/Styled/RegularStudy.regularstudy.home.styles"
 import request from '../../Api/request'
 import { useNavigate, useParams } from 'react-router-dom';
+import hljs from 'highlight.js';
+import 'highlight.js/styles/atom-one-dark.css';
+
 
 export default function RegularStudyHome() {
   const { id } = useParams(); //파라미터로 각 스터디별로 부여된 id를 받아옵니다
@@ -25,6 +28,15 @@ export default function RegularStudyHome() {
     }
     fetchRegularStudyHome();
   }, []);  
+
+  useEffect(() => {
+    // 코드블록에 하이라이트 적용
+    if (regularStudyHome) {
+      document.querySelectorAll('pre').forEach((block) => {
+        hljs.highlightBlock(block);
+      });
+    }
+  }, [regularStudyHome]);
 
   const handleEditStduyInfo = () => {
     navigate(`/editingregularstudyinfo/${id}`);

--- a/src/APP/admin-pages/RegularStudy/Styled/RegularStudy.regularstudy.home.styles.js
+++ b/src/APP/admin-pages/RegularStudy/Styled/RegularStudy.regularstudy.home.styles.js
@@ -26,6 +26,23 @@ export const ContentContainer = styled.div`
   height: 100%;
   margin-bottom: 4.208rem;
   font-size: 0.75rem;
+    pre {
+    background-color: #282c34;  /* 배경색 검정 */
+    color: #abb2bf;  /* 텍스트 색 회색 */
+    padding: 10px;
+    border-radius: 4px;
+    font-family: 'Courier New', Courier, monospace;
+    display: block;
+    overflow-x: auto;
+  }
+
+  code {
+    background-color: #282c34;
+    color: #abb2bf;
+    padding: 10px;
+    border-radius: 4px;
+    font-family: 'Courier New', Courier, monospace;
+  }
 `;
 
 export const BlueContainer = styled.div`


### PR DESCRIPTION
1. 정규스터디 홈 (스터디 소개), 코딩테스트 분석 못생김
    - HTML 불러오는 페이지에서 글자 크기 줄이고, 패딩  추가 → 가독성 좋아진듯

2. 에디터에서는 코드블록 테마 잘 적용되는데, 등록된 글에서는 적용되지 않음
    - 받아온 데이터는 코드블록 형식 잘 지켜짐
    - 따라서 pre 태그가 있는 경우 css로 배경색 + hljs(하이라이트) 라이브러리 + 폰트 적용
    - 개발용 → 정규스터디→에디터 테스트 2 들어가면 보임
    
(tmpContentData는 정규스터디 홈에서 하드코딩하기 위해 만든 파일입니다)