### PR TITLE
[QA] 문의하기 - 에디터 QA

### DIFF
--- a/src/APP/admin-pages/WriteCurriculum/WriteCurriculum.writecurriculum.editor.jsx
+++ b/src/APP/admin-pages/WriteCurriculum/WriteCurriculum.writecurriculum.editor.jsx
@@ -138,7 +138,13 @@ export default function Editor({
           <Styled.OptionLabel>커리큘럼 제목</Styled.OptionLabel>
           <Styled.TextInput 
             value={title} 
-            onChange={(e) => setTitle(e.target.value)} 
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value.length > 250) {
+                alert("제목은 최대 250자까지 입력할 수 있습니다.");
+                return;
+              }
+              setTitle(value)}}
             placeholder="제목을 입력하세요"
           />
 

--- a/src/APP/admin-pages/WriteCurriculum/WriteCurriculum.writecurriculum.main.jsx
+++ b/src/APP/admin-pages/WriteCurriculum/WriteCurriculum.writecurriculum.main.jsx
@@ -108,6 +108,22 @@ export default function WritePost() {
       deleteAllUploadedImages();
     };
   }, []);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      const hasUnsavedChanges = title.trim() !== '' || markdownContent.trim() !== '';
+      if (hasUnsavedChanges) {
+        event.preventDefault();
+        event.returnValue = '';
+      }
+    };
+  
+    window.addEventListener('beforeunload', handleBeforeUnload);
+  
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [title, markdownContent]);
   
   return (
     <Styled.Container>

--- a/src/APP/admin-pages/WriteInstitution/WriteInstitution.writeinstitution.editor.jsx
+++ b/src/APP/admin-pages/WriteInstitution/WriteInstitution.writeinstitution.editor.jsx
@@ -126,7 +126,13 @@ export default function Editor({
           <Styled.OptionLabel>이름</Styled.OptionLabel>
           <Styled.TextInput 
             value={title} 
-            onChange={(e) => setTitle(e.target.value)} 
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value.length > 250) {
+                alert("제목은 최대 250자까지 입력할 수 있습니다.");
+                return;
+              }
+              setTitle(value)}}
             placeholder="기업/부트캠프의 이름을 입력해주세요"
           />
 

--- a/src/APP/admin-pages/WriteInstitution/WriteInstitution.writeinstitution.main.jsx
+++ b/src/APP/admin-pages/WriteInstitution/WriteInstitution.writeinstitution.main.jsx
@@ -116,6 +116,22 @@ export default function WritePost() {
       deleteAllUploadedImages();
     };
   }, []);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      const hasUnsavedChanges = title.trim() !== '' || markdownContent.trim() !== '';
+      if (hasUnsavedChanges) {
+        event.preventDefault();
+        event.returnValue = '';
+      }
+    };
+  
+    window.addEventListener('beforeunload', handleBeforeUnload);
+  
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [title, markdownContent]);
   
   return (
     <Styled.Container>

--- a/src/APP/admin-pages/WritePost/WritePost.writepost.editor.jsx
+++ b/src/APP/admin-pages/WritePost/WritePost.writepost.editor.jsx
@@ -117,7 +117,13 @@ export default function Editor({
           <Styled.OptionLabel>제목</Styled.OptionLabel>
           <Styled.TextInput 
             value={title} 
-            onChange={(e) => setTitle(e.target.value)} 
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value.length > 250) {
+                alert("제목은 최대 250자까지 입력할 수 있습니다.");
+                return;
+              }
+              setTitle(value)}}
             placeholder="제목을 입력하세요"
           />
 

--- a/src/APP/admin-pages/WritePost/WritePost.writepost.main.jsx
+++ b/src/APP/admin-pages/WritePost/WritePost.writepost.main.jsx
@@ -108,6 +108,22 @@ export default function WritePost() {
       deleteAllUploadedImages();
     };
   }, []);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      const hasUnsavedChanges = title.trim() !== '' || markdownContent.trim() !== '';
+      if (hasUnsavedChanges) {
+        event.preventDefault();
+        event.returnValue = '';
+      }
+    };
+  
+    window.addEventListener('beforeunload', handleBeforeUnload);
+  
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [title, markdownContent]);
   
   return (
     <Styled.Container>

--- a/src/APP/admin-pages/WriteRegularStudy/WriteRegularStudy.writeregularstudy.editor.jsx
+++ b/src/APP/admin-pages/WriteRegularStudy/WriteRegularStudy.writeregularstudy.editor.jsx
@@ -172,7 +172,13 @@ export default function Editor({
           <Styled.OptionLabel>스터디 이름</Styled.OptionLabel>
           <Styled.TextInput 
             value={title} 
-            onChange={(e) => setTitle(e.target.value)} 
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value.length > 250) {
+                alert("제목은 최대 250자까지 입력할 수 있습니다.");
+                return;
+              }
+              setTitle(value)}}
             placeholder="이름을 입력해주세요"
           />
 

--- a/src/APP/admin-pages/WriteRegularStudy/WriteRegularStudy.writeregularstudy.main.jsx
+++ b/src/APP/admin-pages/WriteRegularStudy/WriteRegularStudy.writeregularstudy.main.jsx
@@ -137,6 +137,22 @@ useEffect(() => {
       deleteAllUploadedImages();
     };
   }, []);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      const hasUnsavedChanges = title.trim() !== '' || markdownContent.trim() !== '';
+      if (hasUnsavedChanges) {
+        event.preventDefault();
+        event.returnValue = '';
+      }
+    };
+  
+    window.addEventListener('beforeunload', handleBeforeUnload);
+  
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [title, markdownContent]);
   
   return (
     <Styled.Container>


### PR DESCRIPTION
에디터 내부 수정 (WriteCurriculum, WriteInstitution, WritePost, WriteRegularStudy)
- 커뮤니티 제목 너무 긴 경우 alert ✅ 
  - 250자 제한 (300자..? 부터는 오류 발생)
  - return문 내부에 조건 작성
 
- 뒤로가기 시 브라우저 경고창 띄우기 ❌
  - 제목, 내용이 하나라도 채워진 상태라면 확인 팝업 띄우기 (네이버 블로그 UX 참고함)
  - beforeunload 사용 -> 새로고침, 창닫기, url 이동만 가능
  - 뒤로가기는 popstate 사용 필요 -> 적용하면 뒤로가기가 제대로 작동이 안된다. -> 그래서 못했어요

- USER와 수정 사항 같음